### PR TITLE
Create migration to update max size of version string

### DIFF
--- a/src/BaGet.Core/Entities/AbstractContext.cs
+++ b/src/BaGet.Core/Entities/AbstractContext.cs
@@ -10,7 +10,7 @@ namespace BaGet.Core
         public const int DefaultMaxStringLength = 4000;
 
         public const int MaxPackageIdLength = 128;
-        public const int MaxPackageVersionLength = 64;
+        public const int MaxPackageVersionLength = 128;
         public const int MaxPackageMinClientVersionLength = 44;
         public const int MaxPackageLanguageLength = 20;
         public const int MaxPackageTitleLength = 256;

--- a/src/BaGet.Database.MySql/Migrations/20210630025950_IncreaseVersionSize.Designer.cs
+++ b/src/BaGet.Database.MySql/Migrations/20210630025950_IncreaseVersionSize.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using BaGet.Database.MySql;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace BaGet.Database.MySql.Migrations
 {
     [DbContext(typeof(MySqlContext))]
-    partial class MySqlContextModelSnapshot : ModelSnapshot
+    [Migration("20210630025950_IncreaseVersionSize")]
+    partial class IncreaseVersionSize
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BaGet.Database.MySql/Migrations/20210630025950_IncreaseVersionSize.cs
+++ b/src/BaGet.Database.MySql/Migrations/20210630025950_IncreaseVersionSize.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace BaGet.Database.MySql.Migrations
+{
+    public partial class IncreaseVersionSize : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "RowVersion",
+                table: "Packages",
+                rowVersion: true,
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp(6)",
+                oldNullable: true)
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OriginalVersion",
+                table: "Packages",
+                maxLength: 128,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(64) CHARACTER SET utf8mb4",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Version",
+                table: "Packages",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(64) CHARACTER SET utf8mb4",
+                oldMaxLength: 64);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "RowVersion",
+                table: "Packages",
+                type: "timestamp(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldRowVersion: true,
+                oldNullable: true)
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.ComputedColumn);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OriginalVersion",
+                table: "Packages",
+                type: "varchar(64) CHARACTER SET utf8mb4",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 128,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Version",
+                table: "Packages",
+                type: "varchar(64) CHARACTER SET utf8mb4",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldMaxLength: 128);
+        }
+    }
+}


### PR DESCRIPTION
J'ai suivi la procédure pour créer une Database Migration avec EntityFramework Core.
En gros, j'ai changé `AbstractContext.cs` (one-liner), et ensuite j'ai roulé le tool avec 
```
dotnet ef migrations add IncreaseVersionSize --context MySqlContext --output-dir Migrations --startup-project ..\BaGet\BaGet.csproj
```

et les autres fichiers sont auto-généré.  j'ai inspecté le code, et il semble utiliser [la strategy #3 ici](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying?tabs=dotnet-core-cli#apply-migrations-at-runtime).

[On voit ça ici:](https://github.com/coveooss/BaGet/blob/master/src/BaGet/Program.cs#L52)
```
app.OnExecuteAsync(async cancellationToken =>
{
    await host.RunMigrationsAsync(cancellationToken);
```

Et surtout 🤦 
```
        /// <summary>
        /// If enabled, the database will be updated at app startup by running
        /// Entity Framework migrations. This is not recommended in production.
        /// </summary>
        public bool RunMigrationsAtStartup { get; set; } = true;
```
c'est **not recommended in production**, mais c'est à **true** par défaut...

J'ai généré pour le fun les update et rollback scripts:

Update:
```
ALTER TABLE `Packages` MODIFY COLUMN `RowVersion` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);

ALTER TABLE `Packages` MODIFY COLUMN `OriginalVersion` varchar(128) CHARACTER SET utf8mb4 NULL;

ALTER TABLE `Packages` MODIFY COLUMN `Version` varchar(128) CHARACTER SET utf8mb4 NOT NULL;

INSERT INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`)
VALUES ('20210630025950_IncreaseVersionSize', '3.1.1');
```


Rollback:
```
ALTER TABLE `Packages` MODIFY COLUMN `RowVersion` timestamp(6) NULL;

ALTER TABLE `Packages` MODIFY COLUMN `OriginalVersion` varchar(64) CHARACTER SET utf8mb4 NULL;

ALTER TABLE `Packages` MODIFY COLUMN `Version` varchar(64) CHARACTER SET utf8mb4 NOT NULL;

DELETE FROM `__EFMigrationsHistory`
WHERE `MigrationId` = '20210630025950_IncreaseVersionSize';
```
